### PR TITLE
Using capital Type in Content-Type

### DIFF
--- a/src/ServerGrove/KbBundle/Resources/public/js/backend/admin-angular.js
+++ b/src/ServerGrove/KbBundle/Resources/public/js/backend/admin-angular.js
@@ -20,7 +20,7 @@
 
     (function (module) {
         var configFunction = function ($httpProvider) {
-            $httpProvider.defaults.headers.post = {'Content-type': 'application/x-www-form-urlencoded'};
+            $httpProvider.defaults.headers.post = {'Content-Type': 'application/x-www-form-urlencoded'};
         };
         configFunction.$inject = ['$httpProvider'];
         module.config(configFunction);


### PR DESCRIPTION
It looks like post params in Chrome are not correctly sent if the content-type header is not written as Content-Type 

Fixes #3
